### PR TITLE
Debounce input fields

### DIFF
--- a/soi_app.py
+++ b/soi_app.py
@@ -184,6 +184,7 @@ app.layout = dhtml.Div(
                     placeholder=(
                         "E.g., https://docs.python.org/3/library/functions.html#eval"
                     ),
+                    debounce=True,
                 ),
             ]
         ),
@@ -195,6 +196,7 @@ app.layout = dhtml.Div(
                     size="45",
                     id=INPUT_SEARCH,
                     placeholder="E.g., pathlib.Path",
+                    debounce=True,
                 ),
             ]
         ),


### PR DESCRIPTION
Mainly for the URL field, avoids a jumpy cursor when the validation fails.

Resolves #32.